### PR TITLE
Return `nil` when setting content in the buffer

### DIFF
--- a/lib/icy/content_buffer.rb
+++ b/lib/icy/content_buffer.rb
@@ -8,6 +8,7 @@ module Icy
 
     def set(key, value = nil)
       @content_buffer[key] = block_given? ? yield : value
+      nil
     end
 
     def get(key)


### PR DESCRIPTION
This ensures that the act of setting the content buffer doesn’t return the value being set.

This has come up in usage with [slim](https://github.com/slim-template) when trying to capture a block. For the block output to be capture correctly we have to use `=`, which means the return value of the `set` call is output as part of the template.